### PR TITLE
feat: fetch Muse Asia videos

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -5,6 +5,7 @@ import cors from 'cors';
 
 import authRoutes from './routes/auth.js';
 import animeRoutes from './routes/anime.js';
+import youtubeRoutes from './routes/youtube.js';
 
 dotenv.config();
 const app = express();
@@ -13,6 +14,7 @@ app.use(express.json());
 
 app.use('/api/auth', authRoutes);
 app.use('/api/anime', animeRoutes);
+app.use('/api/youtube', youtubeRoutes);
 
 mongoose.connect(process.env.MONGO_URI)
   .then(() => {

--- a/server/routes/youtube.js
+++ b/server/routes/youtube.js
@@ -1,0 +1,29 @@
+import express from 'express';
+
+const router = express.Router();
+
+router.get('/muse-asia', async (req, res) => {
+  try {
+    const apiKey = process.env.YOUTUBE_API_KEY;
+    if (!apiKey) {
+      return res.status(500).json({ error: 'Missing YOUTUBE_API_KEY' });
+    }
+    const channelId = 'UCmOu8FwLycEBqfPjGcOIMbQ';
+    const maxResults = 10;
+    const url = `https://www.googleapis.com/youtube/v3/search?part=snippet&channelId=${channelId}&maxResults=${maxResults}&order=date&type=video&key=${apiKey}`;
+    const response = await fetch(url);
+    const data = await response.json();
+    const videos = data.items?.map((item) => ({
+      id: item.id.videoId,
+      title: item.snippet.title,
+      thumbnail: item.snippet.thumbnails.high?.url || item.snippet.thumbnails.default.url,
+      publishedAt: item.snippet.publishedAt,
+    })) || [];
+    res.json(videos);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch videos' });
+  }
+});
+
+export default router;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,80 +1,22 @@
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Header } from "@/components/Header";
 import { AnimeCard } from "@/components/AnimeCard";
 import { VideoPlayer } from "@/components/VideoPlayer";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { TrendingUp, Clock, Star } from "lucide-react";
-
-// Sample anime data with Muse Asia content
-const animeData = [
-  {
-    id: "1",
-    title: "Demon Slayer: Kimetsu no Yaiba",
-    thumbnail: "https://images.unsplash.com/photo-1578662996442-48f60103fc96?w=400&h=600&fit=crop",
-    episode: "EP 44",
-    rating: 9.2,
-    year: "2024",
-    genre: "Action",
-    videoId: "VQGcpZ2_YPE" // Sample video ID
-  },
-  {
-    id: "2", 
-    title: "Attack on Titan Final Season",
-    thumbnail: "https://images.unsplash.com/photo-1606603124734-a6f64c17cb10?w=400&h=600&fit=crop",
-    episode: "EP 28",
-    rating: 9.5,
-    year: "2023",
-    genre: "Drama",
-    videoId: "SlNpRThS9t8"
-  },
-  {
-    id: "3",
-    title: "Jujutsu Kaisen Season 2",
-    thumbnail: "https://images.unsplash.com/photo-1617696002096-1a0c8e65e9da?w=400&h=600&fit=crop",
-    episode: "EP 23",
-    rating: 8.9,
-    year: "2023",
-    genre: "Supernatural",
-    videoId: "4A_X-Dvl0ws"
-  },
-  {
-    id: "4",
-    title: "One Piece",
-    thumbnail: "https://images.unsplash.com/photo-1606603124734-a6f64c17cb10?w=400&h=600&fit=crop",
-    episode: "EP 1100",
-    rating: 9.0,
-    year: "2024",
-    genre: "Adventure",
-    videoId: "qIG1PiCyJ7s"
-  },
-  {
-    id: "5",
-    title: "My Hero Academia",
-    thumbnail: "https://images.unsplash.com/photo-1578662996442-48f60103fc96?w=400&h=600&fit=crop",
-    episode: "EP 158",
-    rating: 8.7,
-    year: "2024",
-    genre: "Superhero",
-    videoId: "D5fYOnwYkj4"
-  },
-  {
-    id: "6",
-    title: "Chainsaw Man",
-    thumbnail: "https://images.unsplash.com/photo-1617696002096-1a0c8e65e9da?w=400&h=600&fit=crop",
-    episode: "EP 12",
-    rating: 8.8,
-    year: "2023",
-    genre: "Horror",
-    videoId: "v4ylerTL77o"
-  }
-];
+import { getMuseAsiaVideos, YouTubeVideo } from "@/services/youtube";
 
 const Index = () => {
   const [selectedVideo, setSelectedVideo] = useState<{ id: string; title: string } | null>(null);
+  const { data: videos = [] } = useQuery<YouTubeVideo[]>({
+    queryKey: ["museasia-videos"],
+    queryFn: getMuseAsiaVideos,
+  });
 
-  const handleAnimeClick = (anime: typeof animeData[0]) => {
-    setSelectedVideo({ id: anime.videoId, title: anime.title });
+  const handleVideoClick = (video: YouTubeVideo) => {
+    setSelectedVideo({ id: video.id, title: video.title });
   };
 
   return (
@@ -152,16 +94,16 @@ const Index = () => {
           </div>
           
           <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-6">
-            {animeData.map((anime) => (
+            {videos.map((video) => (
               <AnimeCard
-                key={anime.id}
-                title={anime.title}
-                thumbnail={anime.thumbnail}
-                episode={anime.episode}
-                rating={anime.rating}
-                year={anime.year}
-                genre={anime.genre}
-                onClick={() => handleAnimeClick(anime)}
+                key={video.id}
+                title={video.title}
+                thumbnail={video.thumbnail}
+                episode="Video"
+                rating={0}
+                year={new Date(video.publishedAt).getFullYear().toString()}
+                genre="Muse Asia"
+                onClick={() => handleVideoClick(video)}
               />
             ))}
           </div>

--- a/src/services/youtube.ts
+++ b/src/services/youtube.ts
@@ -1,0 +1,14 @@
+export interface YouTubeVideo {
+  id: string;
+  title: string;
+  thumbnail: string;
+  publishedAt: string;
+}
+
+export const getMuseAsiaVideos = async (): Promise<YouTubeVideo[]> => {
+  const res = await fetch('http://localhost:5000/api/youtube/muse-asia');
+  if (!res.ok) {
+    throw new Error('Failed to fetch videos');
+  }
+  return res.json();
+};


### PR DESCRIPTION
## Summary
- add backend route to fetch Muse Asia channel videos via YouTube API
- expose new frontend service and query to display videos

## Testing
- `npm run lint` (fails: An interface declaring no members is equivalent to its supertype; A `require()` style import is forbidden)
- `npm test` (fails: Missing script: "test")
- `cd server && npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689055edd70c832193f5d3f9d9af61e4